### PR TITLE
Rebuild image name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,5 +27,5 @@ packages =
 
 [entry_points]
 console_scripts =
-    slurm-openstack-rebuild = slurm_openstack_tools.reboot:rebuild_or_reboot
+    slurm-openstack-rebuild = slurm_openstack_tools.reboot:main
     slurm-stats = slurm_openstack_tools.sacct:main

--- a/slurm_openstack_tools/reboot.py
+++ b/slurm_openstack_tools/reboot.py
@@ -30,6 +30,7 @@ MAX_REASON_LENGTH = 1000
 logger = logging.getLogger("syslogger")
 logger.setLevel(logging.DEBUG)
 handler = logging.handlers.SysLogHandler("/dev/log")
+handler.setFormatter(logging.Formatter(sys.argv[0] + ': %(message)s'))
 logger.addHandler(handler)
 
 INSTANCE_UUID_FILE = "/var/lib/cloud/data/instance-id"
@@ -144,3 +145,10 @@ def rebuild_or_reboot():
         else:
             logger.info("rebuilding openstack server")
             rebuild_openstack_server(server_uuid, reason)
+
+def main():
+    try:
+        rebuild_or_reboot()
+    except:
+        logger.exception('Exception in rebuild_or_reboot():')
+        raise


### PR DESCRIPTION
As raised [here](https://github.com/stackhpc/ansible_collection_slurm_openstack_tools/issues/39), currently a rebuild request fails pretty quietly if the image ID used is wrong. This PR adds checking for that, and also adds the ability to specify the image by name (because that's basically "free" if validating an image ID anyway).