### PR TITLE
Add ports to ResumeProgram ports and add ResumeFailProgram

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,4 +30,5 @@ console_scripts =
     slurm-openstack-rebuild = slurm_openstack_tools.reboot:main
     slurm-stats = slurm_openstack_tools.sacct:main
     slurm-openstack-resume = slurm_openstack_tools.resume:main
+    slurm-openstack-resumefail = slurm_openstack_tools.resumefail:main
     slurm-openstack-suspend = slurm_openstack_tools.suspend:main

--- a/slurm_openstack_tools/resume.py
+++ b/slurm_openstack_tools/resume.py
@@ -158,7 +158,8 @@ def resume():
                 )
 
         # get optional port - done outside os_objects so an error finding network doesn't cause unhelpful port traceback:
-        os_objects['port'] = conn.network.find_port(node, network_id=os_objects['network'].id)
+        os_portname = features[node].get('port_prefix', '') + node
+        os_objects['port'] = conn.network.find_port(os_portname, network_id=os_objects['network'].id)
 
         if debug:
             logger.info(f"os_objects for {node} : {os_objects}")

--- a/slurm_openstack_tools/resume.py
+++ b/slurm_openstack_tools/resume.py
@@ -159,8 +159,6 @@ def resume():
             logger.info(f"os_objects for {node} : {os_objects}")
         if not debug:
             logger.info(f"creating node {node}")
-            # TODO(stevebrasier): save id to disk so can use it instead of name
-            # on deletion (to cope with multiple instances with same name)
             server = create_server(conn, node, **os_objects)
             logger.info(f"server: {server}")
             with open(os.path.join(statedir, node), 'w') as f:

--- a/slurm_openstack_tools/resume.py
+++ b/slurm_openstack_tools/resume.py
@@ -158,8 +158,7 @@ def resume():
                 )
 
         # get optional port - done outside os_objects so an error finding network doesn't cause unhelpful port traceback:
-        os_portname = os_parameters.get('port_prefix', '') + node
-        os_objects['port'] = conn.network.find_port(os_portname, network_id=os_objects['network'].id)
+        os_objects['port'] = conn.network.find_port(node, network_id=os_objects['network'].id)
 
         if debug:
             logger.info(f"os_objects for {node} : {os_objects}")

--- a/slurm_openstack_tools/resume.py
+++ b/slurm_openstack_tools/resume.py
@@ -150,7 +150,7 @@ def resume():
             'network': conn.network.find_network(os_parameters['network']),
             'keypair': conn.compute.find_keypair(os_parameters['keypair']),
         }
-        not_found = dict([(k, v) for (k, v) in os_parameters.items() if os_objects[k] is None])
+        not_found = dict([(k, os_parameters[k]) for (k, v) in os_objects.items() if v is None])
         if not_found:
             raise ValueError(
                 'Could not find openstack objects for: '
@@ -158,7 +158,7 @@ def resume():
                 )
 
         # get optional port - done outside os_objects so an error finding network doesn't cause unhelpful port traceback:
-        os_portname = features[node].get('port_prefix', '') + node
+        os_portname = os_parameters.get('port_prefix', '') + node
         os_objects['port'] = conn.network.find_port(os_portname, network_id=os_objects['network'].id)
 
         if debug:

--- a/slurm_openstack_tools/resume.py
+++ b/slurm_openstack_tools/resume.py
@@ -100,11 +100,11 @@ def get_features(nodenames):
     return features
 
 
-def create_server(conn, name, image, flavor, network, keypair):
+def create_server(conn, name, image, flavor, network, keypair, port=None):
 
     server = conn.compute.create_server(
         name=name, image_id=image.id, flavor_id=flavor.id,
-        networks=[{"uuid": network.id}], key_name=keypair.name,
+        networks=[{"port": port.id}] if port else [{"uuid": network.id}],
     )
     # server = conn.compute.wait_for_server(...)
 
@@ -156,6 +156,10 @@ def resume():
                 'Could not find openstack objects for: '
                 ', '.join([f'{k}={v}' for (k, v) in not_found.items()])
                 )
+
+        # get optional port - done outside os_objects so an error finding network doesn't cause unhelpful port traceback:
+        os_objects['port'] = conn.network.find_port(node, network_id=os_objects['network'].id)
+
         if debug:
             logger.info(f"os_objects for {node} : {os_objects}")
         if not debug:

--- a/slurm_openstack_tools/resume.py
+++ b/slurm_openstack_tools/resume.py
@@ -150,11 +150,12 @@ def resume():
             'network': conn.network.find_network(os_parameters['network']),
             'keypair': conn.compute.find_keypair(os_parameters['keypair']),
         }
-        not_found = dict((k, v) for (k, v) in os_objects.items() if v is None)
+        not_found = dict([(k, v) for (k, v) in os_parameters.items() if os_objects[k] is None])
         if not_found:
             raise ValueError(
-                'Could not find openstack objects for: %s' %
-                ', '.join(not_found))
+                'Could not find openstack objects for: '
+                ', '.join([f'{k}={v}' for (k, v) in not_found.items()])
+                )
         if debug:
             logger.info(f"os_objects for {node} : {os_objects}")
         if not debug:

--- a/slurm_openstack_tools/resumefail.py
+++ b/slurm_openstack_tools/resumefail.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""A Slurm ResumeFail for OpenStack instances.
+
+This simply resumes any DOWN nodes for which there is no corresponding cloud instance.
+
+Usage:
+
+    resumefail HOSTLIST_EXPRESSION
+
+where: HOSTLIST_EXPRESSION: Name(s) of node(s) which have failed  using Slurm's
+    hostlist expression, as per [1].
+
+Output and exceptions are written to the syslog.
+
+OpenStack credentials must be available to this script (e.g. via an
+application credential in /etc/openstack/clouds.yaml readable by the slurm
+user).
+
+[1]: https://slurm.schedmd.com/slurm.conf.html#OPT_ResumeFailProgram
+
+"""
+
+import logging.handlers
+import os
+import subprocess
+import sys
+
+import openstack
+
+# configure logging to syslog - by default only "info" and above
+# categories appear
+logger = logging.getLogger("syslogger")
+logger.setLevel(logging.DEBUG)
+handler = logging.handlers.SysLogHandler("/dev/log")
+handler.setFormatter(logging.Formatter(sys.argv[0] + ': %(message)s'))
+logger.addHandler(handler)
+
+def expand_nodes(hostlist_expr):
+    scontrol = subprocess.run(
+        ['scontrol', 'show', 'hostnames', hostlist_expr],
+        stdout=subprocess.PIPE, universal_newlines=True)
+    return scontrol.stdout.strip().split('\n')
+
+
+def resumefail():
+    hostlist_expr = sys.argv[1]
+    logger.info(f"Slurmctld invoked resumefail {hostlist_expr}")
+    failed_nodes = expand_nodes(hostlist_expr)
+
+    conn = openstack.connection.from_config()
+    logger.info(f"Got openstack connection {conn}")
+
+    statedir = get_statesavelocation()
+
+    for node in failed_nodes:
+        server = conn.compute.find_server(node)
+        if server is None:
+            logger.info(f"No server found for {node}, resuming")
+            scontrol = subprocess.run(['scontrol', 'update', 'state=resume', 'nodename=%s' % node],
+                stdout=subprocess.PIPE, universal_newlines=True)
+
+def main():
+    try:
+        resumefail()
+    except BaseException:
+        logger.exception('Exception in main:')
+        raise

--- a/slurm_openstack_tools/resumefail.py
+++ b/slurm_openstack_tools/resumefail.py
@@ -40,6 +40,8 @@ import sys
 
 import openstack
 
+SCONTROL_PATH = '/usr/bin/scontrol'
+
 # configure logging to syslog - by default only "info" and above
 # categories appear
 logger = logging.getLogger("syslogger")
@@ -50,7 +52,7 @@ logger.addHandler(handler)
 
 def expand_nodes(hostlist_expr):
     scontrol = subprocess.run(
-        ['scontrol', 'show', 'hostnames', hostlist_expr],
+        [SCONTROL_PATH, 'show', 'hostnames', hostlist_expr],
         stdout=subprocess.PIPE, universal_newlines=True)
     return scontrol.stdout.strip().split('\n')
 
@@ -69,7 +71,7 @@ def resumefail():
         server = conn.compute.find_server(node)
         if server is None:
             logger.info(f"No server found for {node}, resuming")
-            scontrol = subprocess.run(['scontrol', 'update', 'state=resume', 'nodename=%s' % node],
+            scontrol = subprocess.run([SCONTROL_PATH, 'update', 'state=resume', 'nodename=%s' % node],
                 stdout=subprocess.PIPE, universal_newlines=True)
 
 def main():
@@ -78,3 +80,8 @@ def main():
     except BaseException:
         logger.exception('Exception in main:')
         raise
+
+if __name__ == '__main__':
+    # running for testing
+    handler = logging.StreamHandler() # log to console
+    main()

--- a/slurm_openstack_tools/resumefail.py
+++ b/slurm_openstack_tools/resumefail.py
@@ -65,8 +65,6 @@ def resumefail():
     conn = openstack.connection.from_config()
     logger.info(f"Got openstack connection {conn}")
 
-    statedir = get_statesavelocation()
-
     for node in failed_nodes:
         server = conn.compute.find_server(node)
         if server is None:


### PR DESCRIPTION
Improves support for autoscaling:
- Modifies ResumeProgram: If a port is found on the specified network with the same name as the node, the instance is attached to that port. Allows for using predefined ports for e.g. non-default binding configurations or no DNS,
- Adds ResumeFailProgram: Handles cases for failed Resume (nodes -> DOWN where:
  - Instance not created: Node set to `resume` state to allow Slurm to retry that node (as required by scheduler)
  - Instance created but in error state due to "not enough hosts available": instance deleted, node set to `resume` state.