### PR TITLE
Fix sacct parsing for jobs cancelled before starting

### DIFF
--- a/slurm_openstack_tools/sacct.py
+++ b/slurm_openstack_tools/sacct.py
@@ -80,7 +80,7 @@ def main():
             item["AllNodesRegex"] = nodes_regex
 
         start = item.get("Start")
-        if start:
+        if start and start != 'None': # latter is job cancelled before starting
             item["StartEpoch"] = int(datetime.datetime.strptime(
                 start, SLURM_DATE_FORMAT).timestamp() * 1000)
 


### PR DESCRIPTION
Example sacct output for the case which causes failure:
```
[root@control cloud-user]# sacct --format jobid,start,end --starttime=2023-01-01
JobID                      Start                 End 
------------ ------------------- ------------------- 
...
4            2023-04-19T12:40:19 2023-04-19T12:40:19 
4.batch      2023-04-12T15:45:20 2023-04-19T13:53:32 
5                           None 2023-04-19T13:17:06 
6                           None 2023-04-19T13:17:06 
7            2023-04-19T13:54:08 2023-04-19T13:54:08 
```

Once merged this fix will be deployed by running `ansible/monitoring.yml` on any appliance, as [`pytools_gitref`](https://github.com/stackhpc/ansible_collection_slurm_openstack_tools/blob/main/roles/pytools/tasks/main.yml#L24) which installs this is defaulted to `main`.
